### PR TITLE
Rebuild audio source each time audio is played

### DIFF
--- a/src/services/audioServiceWriter.ts
+++ b/src/services/audioServiceWriter.ts
@@ -8,11 +8,11 @@ type audioServiceWriter = {
 }
 
 export interface ISourceSetter {
-  setPlaybackSource(file: File): Promise<AudioSource>;
+  setPlaybackSource(file: File): Promise<void>;
 
   clearPlaybackSource(): void;
 
-  setRecordedSource(file: File): Promise<AudioSource>;
+  setRecordedSource(file: File): Promise<void>;
 
   clearRecordedSource(): void;
 }

--- a/src/services/types.d.ts
+++ b/src/services/types.d.ts
@@ -1,1 +1,2 @@
 type AudioSource = AudioBufferSourceNode | undefined;
+type Buffer = AudioBuffer | undefined;


### PR DESCRIPTION
`.start()` cannot be called multiple times on a `AudioSourceNode`, so the source has to be recreated each time play is called to enable a file to be played multiple times. See [here](https://developer.chrome.com/blog/web-audio-faq/#q-ive-got-an-audiobuffersourcenode-that-i-just-played-back-with-noteon-and-i-want-to-play-it-again-but-noteon-doesnt-do-anything-help) for more details.