### PR TITLE
Add initial file select screen

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,38 +1,3 @@
 .App {
   text-align: center;
 }
-
-.App-logo {
-  height: 40vmin;
-  pointer-events: none;
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  .App-logo {
-    animation: App-logo-spin infinite 20s linear;
-  }
-}
-
-.App-header {
-  background-color: #282c34;
-  min-height: 100vh;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  font-size: calc(10px + 2vmin);
-  color: white;
-}
-
-.App-link {
-  color: #61dafb;
-}
-
-@keyframes App-logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
-}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import React, {useState} from 'react';
 import {FileSelector} from "./components/fileSelector/FileSelector";
-import logo from './logo.svg';
+import {MainFileSelector} from "./components/mainFileSelector/MainFileSelector";
 import './App.css';
 import {AudioService} from "./services/audioService";
 import {getAudioServiceWriter} from "./services/audioServiceWriter";
@@ -19,13 +19,20 @@ function App() {
     clearRecordingSource
   } = getAudioServiceWriter(audioService, setSelected, setRecorded);
 
-  return (
-    <div className="App">
-      <FileSelector audioSelected={selected} setPlayback={setPlaybackSource}></FileSelector>
-      {selected ? <AudioPlayer audioService={audioService}></AudioPlayer> : ""}
-      <AudioRecorder setRecorded={setRecordingSource}></AudioRecorder>
-    </div>
-  );
+  if (selected) {
+    return (
+      <div className="App">
+        <FileSelector audioSelected={selected} setPlayback={setPlaybackSource}></FileSelector>
+        {selected ? <AudioPlayer audioService={audioService}></AudioPlayer> : ""}
+        <AudioRecorder setRecorded={setRecordingSource}></AudioRecorder>
+      </div>
+    );
+
+  } else {
+    return (
+      <MainFileSelector setPlayback={setPlaybackSource}></MainFileSelector>
+    )
+  }
 }
 
 export default App;

--- a/src/components/mainFileSelector/MainFileSelector.css
+++ b/src/components/mainFileSelector/MainFileSelector.css
@@ -1,0 +1,33 @@
+label.main-selector input[type="file"] {
+  display: none;
+}
+
+.main-selector {
+  padding: 0.7rem 1.4rem;
+  font-weight: 600;
+  font-size: 1rem;
+  justify-content: space-between;
+  cursor: pointer;
+  background: var(--color-primary);
+  color: var(--background-color);
+  display: inline-block;
+}
+
+.main-selector-container {
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  column-gap: 1rem;
+}
+
+.learn-more {
+  padding: 0.7rem 1.4rem;
+  font-weight: 600;
+  color: var(--color-text);
+  text-decoration: none;
+}
+
+.learn-more:hover{
+  text-decoration: underline;
+}

--- a/src/components/mainFileSelector/MainFileSelector.tsx
+++ b/src/components/mainFileSelector/MainFileSelector.tsx
@@ -1,0 +1,26 @@
+import React, {ChangeEvent} from 'react'
+import './MainFileSelector.css';
+
+interface FileSelectorProps {
+  setPlayback(file: File): Promise<void>
+}
+
+export function MainFileSelector(props: FileSelectorProps) {
+
+  async function handleUploadChange(event: ChangeEvent<HTMLInputElement>) {
+    if (event.target.files) {
+      await props.setPlayback(event.target.files[0]);
+    }
+  }
+
+  return (
+    <div className="main-selector-container">
+      <label className="main-selector">
+        <input type="file" id="select-file" name="file" accept=".mp3" onChange={handleUploadChange}/>
+        <span>Select a file</span>
+      </label>
+      {/*todo: add learn more/landing page*/}
+      <a className="learn-more" href="/about" target="_blank" rel="noopener noreferrer">Learn more</a>
+    </div>
+  )
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,13 +1,23 @@
+html {
+  font-size: 22px;
+}
+
+html, body, #root {
+  height: 100%;
+}
+
+:root {
+  --background-color: #fafafa;
+  --color-text: #222;
+  --color-primary: #ef3340;
+}
+
 body {
   margin: 0;
+  background-color: var(--background-color);
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
     'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-}
-
-code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
-    monospace;
 }


### PR DESCRIPTION
So that the app doesn't look as janky without any files loaded, this adds an initial screen to select a file, with a link to an info/landing page. The landing page is a to do at a later stage - current plans are to make it just a static page that opens in a new tab, so there's no need to add any routing to the app.

![image](https://user-images.githubusercontent.com/1094516/182021714-e31b4d07-a72a-4703-afcf-a73a2850f5fd.png)
