### PR TITLE
Add record button

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,13 +4,17 @@ import './App.css'
 import { RootState } from './app/store'
 import { MainFileSelector } from './components/mainFileSelector/MainFileSelector'
 import { PlayButton } from './components/playButton/PlayButton'
+import { RecordButton } from './components/recordButton/RecordButton'
 
 function App() {
   const selected = useSelector((state: RootState) => state.playbackFile.set)
 
   if (selected) {
     return (
-      <PlayButton/>
+      <div>
+        <PlayButton/>
+        <RecordButton/>
+      </div>
     )
 
   } else {

--- a/src/app/audioServiceMiddleware.ts
+++ b/src/app/audioServiceMiddleware.ts
@@ -1,8 +1,9 @@
 import type { TypedStartListening } from '@reduxjs/toolkit'
 import { createListenerMiddleware } from '@reduxjs/toolkit'
 import { AudioServiceSingleton } from '../audioService/audioService'
-import { play, stop } from './audioStatus'
+import { playAudio, stopAudio } from './audioStatus'
 import { setPlaybackFile } from './playbackFileSlice'
+import { startRecording, stopRecording } from './recordingSlice'
 
 import type { AppDispatch, RootState } from './store'
 
@@ -15,15 +16,15 @@ export const startAppListening = audioServiceMiddleware.startListening as AppSta
 const audioService = AudioServiceSingleton.getInstance()
 
 startAppListening({
-  actionCreator: play,
+  actionCreator: playAudio,
   effect: (_, listenerApi) => {
-    const stopOnEnd = () => listenerApi.dispatch(stop())
-    audioService.play(stopOnEnd)
+    const stopOnEnd = () => listenerApi.dispatch(stopAudio())
+    audioService.start(stopOnEnd)
   }
 })
 
 startAppListening({
-  actionCreator: stop,
+  actionCreator: stopAudio,
   effect: () => {
     audioService.stop()
   }
@@ -33,5 +34,20 @@ startAppListening({
   actionCreator: setPlaybackFile,
   effect: async (action) => {
     await audioService.setPlaybackFile(action.payload)
+  }
+})
+
+startAppListening({
+  actionCreator: startRecording,
+  effect: (_, listenerApi) => {
+    const stopOnEnd = () => listenerApi.dispatch(stopRecording())
+    audioService.record(stopOnEnd)
+  }
+})
+
+startAppListening({
+  actionCreator: stopRecording,
+  effect: () => {
+    audioService.stop()
   }
 })

--- a/src/app/audioStatus.ts
+++ b/src/app/audioStatus.ts
@@ -13,21 +13,15 @@ export const audioStateSlice = createSlice({
   name: 'audioState',
   initialState: initialState,
   reducers: {
-    play: (state) => {
+    playAudio: (state) => {
       state.status = AudioStatus.Playing
     },
-    pause: (state) => {
-      state.status = AudioStatus.Paused
-    },
-    record: (state) => {
-      state.status = AudioStatus.Recording
-    },
-    stop: (state) => {
+    stopAudio: (state) => {
       state.status = AudioStatus.Stopped
     }
   }
 })
 
-export const { play, pause, record, stop } = audioStateSlice.actions
+export const { playAudio, stopAudio } = audioStateSlice.actions
 
 export const audioReducer = audioStateSlice.reducer

--- a/src/app/recordingSlice.ts
+++ b/src/app/recordingSlice.ts
@@ -1,0 +1,37 @@
+import { createSlice } from '@reduxjs/toolkit'
+
+export interface SourcesState {
+  isRecording: boolean
+  recordedSet: boolean
+}
+
+const initialState: SourcesState = {
+  isRecording: false,
+  recordedSet: false
+}
+
+export const recordingSlice = createSlice({
+  name: 'recording',
+  initialState: initialState,
+  reducers: {
+    startRecording: (state) => {
+      state.isRecording = true
+      state.recordedSet = false
+    },
+    stopRecording: (state) => {
+      state.isRecording = false
+      state.recordedSet = true
+    },
+    clearRecorded: (state) => {
+      state.recordedSet = false
+    }
+  }
+})
+
+export const {
+  startRecording,
+  stopRecording,
+  clearRecorded
+} = recordingSlice.actions
+
+export const recordingReducer = recordingSlice.reducer

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -2,11 +2,13 @@ import { configureStore } from '@reduxjs/toolkit'
 import { audioServiceMiddleware } from './audioServiceMiddleware'
 import { audioReducer } from './audioStatus'
 import { playbackFileReducer, setPlaybackFile } from './playbackFileSlice'
+import { recordingReducer } from './recordingSlice'
 
 export const store = configureStore({
   reducer: {
     audio: audioReducer,
-    playbackFile: playbackFileReducer
+    playbackFile: playbackFileReducer,
+    recording: recordingReducer
   },
   middleware: (getDefaultMiddleware) =>
     getDefaultMiddleware(

--- a/src/components/icons/icons.tsx
+++ b/src/components/icons/icons.tsx
@@ -1,5 +1,8 @@
 import React from 'react'
 
+// Fluent UI System Icons from Microsoft
+// https://github.com/microsoft/fluentui-system-icons
+
 export const PlayIcon = () =>
   <svg width="24" height="24" fill="none" viewBox="0 0 24 24"
        xmlns="http://www.w3.org/2000/svg">
@@ -25,18 +28,16 @@ export const StopIcon = () =>
   </svg>
 
 export const RecordIcon = () =>
-  <svg width="24" height="24" fill="none" viewBox="0 0 24 24"
-       xmlns="http://www.w3.org/2000/svg">
+  <svg width="24" height="24" fill="none" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
     <path
-      d="M2 12C2 6.477 6.477 2 12 2s10 4.477 10 10-4.477 10-10 10S2 17.523 2 12Zm10 6a6 6 0 1 0 0-12 6 6 0 0 0 0 12Z"
+      d="M18.25 11a.75.75 0 0 1 .743.648l.007.102v.5a6.75 6.75 0 0 1-6.249 6.732l-.001 2.268a.75.75 0 0 1-1.493.102l-.007-.102v-2.268a6.75 6.75 0 0 1-6.246-6.496L5 12.25v-.5a.75.75 0 0 1 1.493-.102l.007.102v.5a5.25 5.25 0 0 0 5.034 5.246l.216.004h.5a5.25 5.25 0 0 0 5.246-5.034l.004-.216v-.5a.75.75 0 0 1 .75-.75ZM12 2a4 4 0 0 1 4 4v6a4 4 0 0 1-8 0V6a4 4 0 0 1 4-4Z"
       fill="var(--button-color)"/>
   </svg>
 
 export const RecordStopIcon = () =>
-  <svg width="24" height="24" fill="none" viewBox="0 0 24 24"
-       xmlns="http://www.w3.org/2000/svg">
+  <svg width="24" height="24" fill="none" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
     <path
-      d="M12 22c5.523 0 10-4.477 10-10S17.523 2 12 2 2 6.477 2 12s4.477 10 10 10ZM9.5 8h5A1.5 1.5 0 0 1 16 9.5v5a1.5 1.5 0 0 1-1.5 1.5h-5A1.5 1.5 0 0 1 8 14.5v-5A1.5 1.5 0 0 1 9.5 8Z"
+      d="M3.28 2.22a.75.75 0 1 0-1.06 1.06L8 9.06V12a4 4 0 0 0 6.248 3.309l1.146 1.146A5.227 5.227 0 0 1 12.25 17.5h-.5l-.216-.004A5.25 5.25 0 0 1 6.5 12.25v-.5l-.007-.102A.75.75 0 0 0 5 11.75v.5l.004.236a6.75 6.75 0 0 0 6.246 6.496v2.268l.007.102a.75.75 0 0 0 1.493-.102l.001-2.268a6.718 6.718 0 0 0 3.712-1.458l4.256 4.256a.75.75 0 0 0 1.061-1.06L3.28 2.22ZM17.196 14.014l1.146 1.146A6.725 6.725 0 0 0 19 12.25v-.5l-.007-.102a.75.75 0 0 0-1.493.102v.5l-.004.216a5.233 5.233 0 0 1-.3 1.548ZM8.138 4.956l7.792 7.792c.046-.242.07-.492.07-.748V6a4 4 0 0 0-7.862-1.044Z"
       fill="var(--button-color)"/>
   </svg>
 

--- a/src/components/playButton/PlayButton.tsx
+++ b/src/components/playButton/PlayButton.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { useDispatch, useSelector } from 'react-redux'
-import { play, stop } from '../../app/audioStatus'
+import { playAudio, stopAudio } from '../../app/audioStatus'
 import { RootState } from '../../app/store'
 import { AudioStatus } from '../../constants/audioStatus'
 import { PlayIcon, StopIcon } from '../icons/icons'
@@ -28,13 +28,13 @@ export function PlayButton() {
   function handleClick() {
     switch (status) {
       case AudioStatus.Playing:
-        dispatch(stop())
+        dispatch(stopAudio())
         break
       case AudioStatus.Paused:
-        dispatch(play())
+        dispatch(playAudio())
         break
       case AudioStatus.Stopped:
-        dispatch(play())
+        dispatch(playAudio())
         break
     }
   }

--- a/src/components/recordButton/RecordButton.tsx
+++ b/src/components/recordButton/RecordButton.tsx
@@ -1,0 +1,22 @@
+import React from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+import { startRecording, stopRecording } from '../../app/recordingSlice'
+import { RootState } from '../../app/store'
+import { RecordIcon, RecordStopIcon } from '../icons/icons'
+import '../styles/Button.css'
+
+
+export function RecordButton() {
+  const isRecording = useSelector((state: RootState) => state.recording.isRecording)
+  const dispatch = useDispatch()
+
+  const Icon = isRecording ? RecordStopIcon : RecordIcon
+
+  const handleClick = () => isRecording ? dispatch(stopRecording()) : dispatch(startRecording())
+
+  return (
+    <button className="round-button" onClick={handleClick}>
+      <Icon/>
+    </button>
+  )
+}


### PR DESCRIPTION
This PR brings the record button back in. Compared to the [previous](https://github.com/hyperbolae/shadowingly/blob/8299016b144c9f4e5a60a6468a3fe63bc6ce7408/src/components/audioRecorder/AudioRecorder.tsx) component, the base logic is the same, but it's just moved to the audio service. The audio service is looking a bit chonky, so I'm not sure if we want to break it up?

In terms of functionality changes, the uploaded file will now play at the same time as the audio, and clicking on the play button will playback both uploaded and recorded audio at the same time. 