### PR TITLE
Add simple waveform for playback

### DIFF
--- a/src/app/audioServiceMiddleware.ts
+++ b/src/app/audioServiceMiddleware.ts
@@ -2,7 +2,7 @@ import type { TypedStartListening } from "@reduxjs/toolkit"
 import { createListenerMiddleware } from "@reduxjs/toolkit"
 import { AudioServiceSingleton } from "../audioService/audioService"
 import { pauseAudio, playAudio, startRecording, stopAudio, stopRecording } from "./audioSlice"
-import { _setPlaybackFile } from "./playbackFileSlice"
+import { _setPlaybackFile, setPlaybackFileLoaded } from "./playbackFileSlice"
 
 import type { AppDispatch, RootState } from "./store"
 
@@ -38,8 +38,9 @@ startAppListening({
 
 startAppListening({
   actionCreator: _setPlaybackFile,
-  effect: async (action) => {
+  effect: async (action, listenerApi) => {
     await audioService.setPlaybackFile(action.payload)
+    listenerApi.dispatch(setPlaybackFileLoaded())
   }
 })
 

--- a/src/app/playbackFileSlice.ts
+++ b/src/app/playbackFileSlice.ts
@@ -27,7 +27,6 @@ export const playbackFileSlice = createSlice({
       state.loaded = false
     },
     setPlaybackFileLoaded: (state) => {
-      console.log("LOADED")
       state.loaded = true
     }
   }

--- a/src/app/playbackFileSlice.ts
+++ b/src/app/playbackFileSlice.ts
@@ -5,25 +5,32 @@ import { AppThunk } from "./store"
 import { setCurrentView } from "./viewSlice"
 
 export interface PlaybackFileState {
-  set: boolean
+  set: boolean;
+  loaded: boolean;
 }
 
 const initialState: PlaybackFileState = {
-  set: false
-}
+  set: false,
+  loaded: false,
+};
 
 export const playbackFileSlice = createSlice({
   name: "playbackFile",
   initialState: initialState,
   reducers: {
     _setPlaybackFile: (state, _: PayloadAction<File>) => {
-      state.set = true
+      state.set = true;
+      state.loaded = false;
     },
     clearPlaybackFile: (state) => {
-      state.set = false
-    }
-  }
-})
+      state.set = false;
+      state.loaded = false;
+    },
+    playbackFileLoaded: (state) => {
+      state.loaded = true;
+    },
+  },
+});
 
 export const { _setPlaybackFile } = playbackFileSlice.actions
 

--- a/src/app/playbackFileSlice.ts
+++ b/src/app/playbackFileSlice.ts
@@ -5,34 +5,35 @@ import { AppThunk } from "./store"
 import { setCurrentView } from "./viewSlice"
 
 export interface PlaybackFileState {
-  set: boolean;
-  loaded: boolean;
+  set: boolean
+  loaded: boolean
 }
 
 const initialState: PlaybackFileState = {
   set: false,
-  loaded: false,
-};
+  loaded: false
+}
 
 export const playbackFileSlice = createSlice({
   name: "playbackFile",
   initialState: initialState,
   reducers: {
     _setPlaybackFile: (state, _: PayloadAction<File>) => {
-      state.set = true;
-      state.loaded = false;
+      state.set = true
+      state.loaded = false
     },
     clearPlaybackFile: (state) => {
-      state.set = false;
-      state.loaded = false;
+      state.set = false
+      state.loaded = false
     },
-    playbackFileLoaded: (state) => {
-      state.loaded = true;
-    },
-  },
-});
+    setPlaybackFileLoaded: (state) => {
+      console.log("LOADED")
+      state.loaded = true
+    }
+  }
+})
 
-export const { _setPlaybackFile } = playbackFileSlice.actions
+export const { _setPlaybackFile, setPlaybackFileLoaded } = playbackFileSlice.actions
 
 export const setPlaybackFile =
   (payload: File): AppThunk =>

--- a/src/audioService/audioService.ts
+++ b/src/audioService/audioService.ts
@@ -21,7 +21,7 @@ export class AudioService {
   getCurrentTime = () => this.context.currentTime - this.startTime
   getPlaybackDuration = () => this.playbackBuffer?.duration
   getRecordingDuration = () => this.playbackBuffer?.duration
-  getPlaybackBuffer = () => this.playbackBuffer
+  getPlaybackChannelData = () => this.playbackBuffer?.getChannelData(0)
 
   constructor(context: AudioContext = new AudioContext()) {
     this.context = context

--- a/src/audioService/audioService.ts
+++ b/src/audioService/audioService.ts
@@ -21,6 +21,7 @@ export class AudioService {
   getCurrentTime = () => this.context.currentTime - this.startTime
   getPlaybackDuration = () => this.playbackBuffer?.duration
   getRecordingDuration = () => this.playbackBuffer?.duration
+  getPlaybackBuffer = () => this.playbackBuffer
 
   constructor(context: AudioContext = new AudioContext()) {
     this.context = context

--- a/src/components/shadowing/shadowingLayout/ShadowingLayout.module.css
+++ b/src/components/shadowing/shadowingLayout/ShadowingLayout.module.css
@@ -20,6 +20,5 @@
 
 .playback {
   width: 550px;
-  height: 100px;
   margin-left: 60px;
 }

--- a/src/components/shadowing/shadowingLayout/ShadowingLayout.tsx
+++ b/src/components/shadowing/shadowingLayout/ShadowingLayout.tsx
@@ -14,6 +14,7 @@ export function ShadowingLayout() {
   return (
     <div className={styles.layout}>
       <div className={styles.playback}>
+        <Waveform />
         <ProgressBarContainer />
         <div className={styles.buttons}>
           <RecordButton />

--- a/src/components/shadowing/shadowingLayout/ShadowingLayout.tsx
+++ b/src/components/shadowing/shadowingLayout/ShadowingLayout.tsx
@@ -5,6 +5,7 @@ import { ListeningTypeSelector } from "../channelSelector/ListeningTypeSelector"
 import { PlayButton } from "../playButton/PlayButton"
 import { ProgressBarContainer } from "../progressBar/ProgressBarContainer"
 import { RecordButton } from "../recordButton/RecordButton"
+import { Waveform } from "../waveform/Waveform"
 import styles from "./ShadowingLayout.module.css"
 
 export function ShadowingLayout() {

--- a/src/components/shadowing/waveform/Waveform.tsx
+++ b/src/components/shadowing/waveform/Waveform.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { useAppSelector } from "../../../app/hooks";
 import { useAudioService } from "../../../audioService/hooks";
 
@@ -29,7 +29,7 @@ function chunk_pulse_code_modulation(input: Float32Array, num_chunks: number) {
 
 export function Waveform() {
   const audioService = useAudioService();
-  const set = useAppSelector((state) => state.playbackFile.loaded);
+  useAppSelector((state) => state.playbackFile.loaded);
   useEffect(() => {
     let canvas = document.getElementById("waveform") as HTMLCanvasElement;
     canvas.style.width = "100%";

--- a/src/components/shadowing/waveform/Waveform.tsx
+++ b/src/components/shadowing/waveform/Waveform.tsx
@@ -28,12 +28,12 @@ function chunk_pulse_code_modulation(input: Float32Array, num_chunks: number) {
 export function Waveform() {
   const audioService = useAudioService()
   const canvasRef = useRef<HTMLCanvasElement>(null)
-  const playbackBuffer = audioService.getPlaybackBuffer()
+  const channel_data = audioService.getPlaybackChannelData()
   useAppSelector((state) => state.playbackFile.loaded)
 
   useEffect(() => {
     let canvas = canvasRef.current
-    if (!canvas || !playbackBuffer) {
+    if (!canvas || !channel_data) {
       return
     }
     canvas.style.width = "100%"
@@ -42,7 +42,6 @@ export function Waveform() {
     const context: any = canvas.getContext("2d")!
     const piece_size = canvas.width / waveform_line_count
     context.fillStyle = getComputedStyle(document.documentElement).getPropertyValue("--color-primary")
-    const channel_data = playbackBuffer.getChannelData(0)
     if (channel_data) {
       let volume = chunk_pulse_code_modulation(channel_data, waveform_line_count)
       volume = normalize_array(volume)
@@ -52,6 +51,6 @@ export function Waveform() {
       }
       context.fill()
     }
-  }, [playbackBuffer])
+  }, [channel_data])
   return <canvas ref={canvasRef} width="100%" height="150px"></canvas>
 }

--- a/src/components/shadowing/waveform/Waveform.tsx
+++ b/src/components/shadowing/waveform/Waveform.tsx
@@ -31,7 +31,6 @@ export function Waveform() {
   const audioService = useAudioService();
   const set = useAppSelector((state) => state.playbackFile.loaded);
   useEffect(() => {
-    console.log(audioService.playbackBuffer);
     let canvas = document.getElementById("waveform") as HTMLCanvasElement;
     canvas.style.width = "100%";
     let waveform_line_count = 50;

--- a/src/components/shadowing/waveform/Waveform.tsx
+++ b/src/components/shadowing/waveform/Waveform.tsx
@@ -1,64 +1,51 @@
-import React from "react";
-import { useEffect } from "react";
-import { useAppSelector } from "../../../app/hooks";
-import { useAudioService } from "../../../audioService/hooks";
+import React from "react"
+import { useEffect } from "react"
+import { useAppSelector } from "../../../app/hooks"
+import { useAudioService } from "../../../audioService/hooks"
 
 function normalize_array(input: number[]) {
-  let ratio = Math.max.apply(Math, input) / 100;
-  let normalized: Array<number> = [];
+  let ratio = Math.max.apply(Math, input) / 100
+  let normalized: Array<number> = []
   for (let i = 0; i < input.length; i++) {
-    normalized.push(Math.round(input[i] / ratio));
+    normalized.push(Math.round(input[i] / ratio))
   }
-  return normalized;
+  return normalized
 }
 
 function chunk_pulse_code_modulation(input: Float32Array, num_chunks: number) {
-  let window_size = Math.floor(input!.length / num_chunks);
-  let volume = [];
+  let window_size = Math.floor(input!.length / num_chunks)
+  let volume = []
 
   for (let i = 0; i < num_chunks; i++) {
-    let sum = 0;
-    sum = input
-      .subarray(i * window_size, (i + 1) * window_size)
-      .reduce((acc: number, value: number) => acc + value, 0);
-    sum /= window_size;
-    volume.push(sum);
+    let sum = 0
+    sum = input.subarray(i * window_size, (i + 1) * window_size).reduce((acc: number, value: number) => acc + value, 0)
+    sum /= window_size
+    volume.push(sum)
   }
-  return volume;
+  return volume
 }
 
 export function Waveform() {
-  const audioService = useAudioService();
-  useAppSelector((state) => state.playbackFile.loaded);
+  const audioService = useAudioService()
+  useAppSelector((state) => state.playbackFile.loaded)
   useEffect(() => {
-    let canvas = document.getElementById("waveform") as HTMLCanvasElement;
-    canvas.style.width = "100%";
-    let waveform_line_count = 50;
-    canvas.width = canvas.offsetWidth;
-    let context: any = canvas.getContext("2d")!;
-    let piece_size = canvas.width / waveform_line_count;
-    context.fillStyle = getComputedStyle(
-      document.documentElement,
-    ).getPropertyValue("--color-primary");
-    let channel_data = audioService.playbackBuffer?.getChannelData(0);
+    let canvas = document.getElementById("waveform") as HTMLCanvasElement
+    canvas.style.width = "100%"
+    let waveform_line_count = 50
+    canvas.width = canvas.offsetWidth
+    let context: any = canvas.getContext("2d")!
+    let piece_size = canvas.width / waveform_line_count
+    context.fillStyle = getComputedStyle(document.documentElement).getPropertyValue("--color-primary")
+    let channel_data = audioService.playbackBuffer?.getChannelData(0)
     if (channel_data) {
-      let volume = chunk_pulse_code_modulation(
-        channel_data,
-        waveform_line_count,
-      );
-      volume = normalize_array(volume);
+      let volume = chunk_pulse_code_modulation(channel_data, waveform_line_count)
+      volume = normalize_array(volume)
 
       for (let i = 0; i < waveform_line_count; i++) {
-        context.roundRect(
-          i * piece_size,
-          canvas.height / 2 - 0.25 * volume[i],
-          piece_size * 0.9,
-          0.5 * volume[i],
-          10,
-        );
+        context.roundRect(i * piece_size, canvas.height / 2 - 0.25 * volume[i], piece_size * 0.9, 0.5 * volume[i], 10)
       }
-      context.fill();
+      context.fill()
     }
-  }, [audioService.playbackBuffer]);
-  return <canvas id="waveform" width="100%" height="150px"></canvas>;
+  }, [audioService.playbackBuffer])
+  return <canvas id="waveform" width="100%" height="150px"></canvas>
 }

--- a/src/components/shadowing/waveform/Waveform.tsx
+++ b/src/components/shadowing/waveform/Waveform.tsx
@@ -1,0 +1,65 @@
+import React from "react";
+import { useEffect, useState } from "react";
+import { useAppSelector } from "../../../app/hooks";
+import { useAudioService } from "../../../audioService/hooks";
+
+function normalize_array(input: number[]) {
+  let ratio = Math.max.apply(Math, input) / 100;
+  let normalized: Array<number> = [];
+  for (let i = 0; i < input.length; i++) {
+    normalized.push(Math.round(input[i] / ratio));
+  }
+  return normalized;
+}
+
+function chunk_pulse_code_modulation(input: Float32Array, num_chunks: number) {
+  let window_size = Math.floor(input!.length / num_chunks);
+  let volume = [];
+
+  for (let i = 0; i < num_chunks; i++) {
+    let sum = 0;
+    sum = input
+      .subarray(i * window_size, (i + 1) * window_size)
+      .reduce((acc: number, value: number) => acc + value, 0);
+    sum /= window_size;
+    volume.push(sum);
+  }
+  return volume;
+}
+
+export function Waveform() {
+  const audioService = useAudioService();
+  const set = useAppSelector((state) => state.playbackFile.loaded);
+  useEffect(() => {
+    console.log(audioService.playbackBuffer);
+    let canvas = document.getElementById("waveform") as HTMLCanvasElement;
+    canvas.style.width = "100%";
+    let waveform_line_count = 50;
+    canvas.width = canvas.offsetWidth;
+    let context: any = canvas.getContext("2d")!;
+    let piece_size = canvas.width / waveform_line_count;
+    context.fillStyle = getComputedStyle(
+      document.documentElement,
+    ).getPropertyValue("--color-primary");
+    let channel_data = audioService.playbackBuffer?.getChannelData(0);
+    if (channel_data) {
+      let volume = chunk_pulse_code_modulation(
+        channel_data,
+        waveform_line_count,
+      );
+      volume = normalize_array(volume);
+
+      for (let i = 0; i < waveform_line_count; i++) {
+        context.roundRect(
+          i * piece_size,
+          canvas.height / 2 - 0.25 * volume[i],
+          piece_size * 0.9,
+          0.5 * volume[i],
+          10,
+        );
+      }
+      context.fill();
+    }
+  }, [audioService.playbackBuffer]);
+  return <canvas id="waveform" width="100%" height="150px"></canvas>;
+}


### PR DESCRIPTION
I have added a simple waveform to visualise the playback file. I decided to implement this from scratch rather than use a library since we will have more control over this going forward (having the waveform respond to themes etc).

I have also added `prettier` as a dev dependency. I realise now that this might make the changes hard to review, but I have at least kept this as a separate commit.

![Screenshot at 2023-11-24 10-29-36](https://github.com/hyperbolae/shadowingly/assets/14137201/5c252ce7-6fa9-47c8-8614-bd7c148d6d87)
